### PR TITLE
fix: match actual API response format for status count endpoints

### DIFF
--- a/monitoring_hosts.go
+++ b/monitoring_hosts.go
@@ -16,12 +16,18 @@ type MonitoringHost struct {
 	Status  ResourceStatus `json:"status"`
 }
 
+// StatusValue holds a count with a total subfield, as returned by the Centreon API.
+type StatusValue struct {
+	Total int `json:"total"`
+}
+
 // HostStatusCount holds status counts for hosts.
 type HostStatusCount struct {
-	Up          int `json:"up"`
-	Down        int `json:"down"`
-	Unreachable int `json:"unreachable"`
-	Pending     int `json:"pending"`
+	Up          StatusValue `json:"up"`
+	Down        StatusValue `json:"down"`
+	Unreachable StatusValue `json:"unreachable"`
+	Pending     StatusValue `json:"pending"`
+	Total       int         `json:"total"`
 }
 
 // TimelineEvent represents an event in a resource's timeline.

--- a/monitoring_hosts_test.go
+++ b/monitoring_hosts_test.go
@@ -74,10 +74,11 @@ func TestMonitoringHostService_StatusCounts(t *testing.T) {
 
 	mux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/status", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, HostStatusCount{
-			Up:          10,
-			Down:        2,
-			Unreachable: 1,
-			Pending:     0,
+			Up:          StatusValue{Total: 10},
+			Down:        StatusValue{Total: 2},
+			Unreachable: StatusValue{Total: 1},
+			Pending:     StatusValue{Total: 0},
+			Total:       13,
 		})
 	})
 
@@ -85,14 +86,17 @@ func TestMonitoringHostService_StatusCounts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StatusCounts: %v", err)
 	}
-	if counts.Up != 10 {
-		t.Errorf("Up = %d, want 10", counts.Up)
+	if counts.Up.Total != 10 {
+		t.Errorf("Up.Total = %d, want 10", counts.Up.Total)
 	}
-	if counts.Down != 2 {
-		t.Errorf("Down = %d, want 2", counts.Down)
+	if counts.Down.Total != 2 {
+		t.Errorf("Down.Total = %d, want 2", counts.Down.Total)
 	}
-	if counts.Unreachable != 1 {
-		t.Errorf("Unreachable = %d, want 1", counts.Unreachable)
+	if counts.Unreachable.Total != 1 {
+		t.Errorf("Unreachable.Total = %d, want 1", counts.Unreachable.Total)
+	}
+	if counts.Total != 13 {
+		t.Errorf("Total = %d, want 13", counts.Total)
 	}
 }
 

--- a/monitoring_services.go
+++ b/monitoring_services.go
@@ -14,11 +14,12 @@ type MonitoringService struct {
 
 // ServiceStatusCount holds status counts for services.
 type ServiceStatusCount struct {
-	OK       int `json:"ok"`
-	Warning  int `json:"warning"`
-	Critical int `json:"critical"`
-	Unknown  int `json:"unknown"`
-	Pending  int `json:"pending"`
+	OK       StatusValue `json:"ok"`
+	Warning  StatusValue `json:"warning"`
+	Critical StatusValue `json:"critical"`
+	Unknown  StatusValue `json:"unknown"`
+	Pending  StatusValue `json:"pending"`
+	Total    int         `json:"total"`
 }
 
 // MonitoringServiceService provides access to the monitoring services endpoints.

--- a/monitoring_services_test.go
+++ b/monitoring_services_test.go
@@ -39,11 +39,12 @@ func TestMonitoringServiceService_StatusCounts(t *testing.T) {
 
 	mux.HandleFunc("GET /centreon/api/latest/monitoring/services/status", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, ServiceStatusCount{
-			OK:       50,
-			Warning:  5,
-			Critical: 2,
-			Unknown:  1,
-			Pending:  3,
+			OK:       StatusValue{Total: 50},
+			Warning:  StatusValue{Total: 5},
+			Critical: StatusValue{Total: 2},
+			Unknown:  StatusValue{Total: 1},
+			Pending:  StatusValue{Total: 3},
+			Total:    61,
 		})
 	})
 
@@ -51,13 +52,16 @@ func TestMonitoringServiceService_StatusCounts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StatusCounts: %v", err)
 	}
-	if counts.OK != 50 {
-		t.Errorf("OK = %d, want 50", counts.OK)
+	if counts.OK.Total != 50 {
+		t.Errorf("OK.Total = %d, want 50", counts.OK.Total)
 	}
-	if counts.Warning != 5 {
-		t.Errorf("Warning = %d, want 5", counts.Warning)
+	if counts.Warning.Total != 5 {
+		t.Errorf("Warning.Total = %d, want 5", counts.Warning.Total)
 	}
-	if counts.Critical != 2 {
-		t.Errorf("Critical = %d, want 2", counts.Critical)
+	if counts.Critical.Total != 2 {
+		t.Errorf("Critical.Total = %d, want 2", counts.Critical.Total)
+	}
+	if counts.Total != 61 {
+		t.Errorf("Total = %d, want 61", counts.Total)
 	}
 }


### PR DESCRIPTION
## Summary

- `HostStatusCount` and `ServiceStatusCount` struct fields expect plain `int` but API returns nested `{"total": int}` objects
- Add `StatusValue` type with `Total int` field
- Update both structs and their tests to match actual API response format

## API Response Format

```json
{
    "up": {"total": 123},
    "down": {"total": 4},
    "unreachable": {"total": 1},
    "pending": {"total": 0},
    "total": 128
}
```

## Test plan

- [x] All tests pass (`go test -race ./...`)
- [x] 0 lint issues
- [ ] CodeRabbit review
- [ ] Gemini Code Assist review

Fixes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Monitoring host and service status counts have been restructured with new total aggregate fields and enhanced status detail breakdowns, improving system health visibility and reporting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->