### PR TITLE
fix: correct API paths, payload structures, and HTTP methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ downtimes, _ := client.Downtimes.List(ctx)
 downtimes, _ := client.Downtimes.ListForHost(ctx, hostID)
 
 // Schedule a downtime on a host
-client.Downtimes.CreateForHost(ctx, hostID, &centreon.CreateDowntimeRequest{
+client.Downtimes.CreateForHost(ctx, hostID, &centreon.CreateHostDowntimeRequest{
     Comment:   "Scheduled maintenance",
     StartTime: time.Now(),
     EndTime:   time.Now().Add(2 * time.Hour),
@@ -119,7 +119,7 @@ client.Downtimes.CreateForHost(ctx, hostID, &centreon.CreateDowntimeRequest{
 })
 
 // Schedule a downtime on a service
-client.Downtimes.CreateForService(ctx, hostID, serviceID, &centreon.CreateDowntimeRequest{
+client.Downtimes.CreateForService(ctx, hostID, serviceID, &centreon.CreateServiceDowntimeRequest{
     Comment:   "Service patch",
     StartTime: time.Now(),
     EndTime:   time.Now().Add(30 * time.Minute),
@@ -140,13 +140,13 @@ client.Downtimes.CancelForHost(ctx, hostID)
 acks, _ := client.Acknowledgements.List(ctx)
 
 // Acknowledge a host
-client.Acknowledgements.CreateForHost(ctx, hostID, &centreon.CreateAcknowledgementRequest{
+client.Acknowledgements.CreateForHost(ctx, hostID, &centreon.CreateHostAcknowledgementRequest{
     Comment:  "Investigating",
     IsSticky: true,
 })
 
 // Acknowledge a service
-client.Acknowledgements.CreateForService(ctx, hostID, serviceID, &centreon.CreateAcknowledgementRequest{
+client.Acknowledgements.CreateForService(ctx, hostID, serviceID, &centreon.CreateServiceAcknowledgementRequest{
     Comment:             "Known issue, fix in progress",
     IsSticky:            true,
     IsPersistentComment: true,

--- a/acknowledgements.go
+++ b/acknowledgements.go
@@ -24,13 +24,21 @@ type Acknowledgement struct {
 	DeletionTime        *time.Time `json:"deletion_time"`
 }
 
-// CreateAcknowledgementRequest is the request body for acknowledging a host or service.
-type CreateAcknowledgementRequest struct {
+// CreateHostAcknowledgementRequest is the request body for acknowledging a host.
+type CreateHostAcknowledgementRequest struct {
 	Comment             string `json:"comment"`
 	IsNotifyContacts    bool   `json:"is_notify_contacts"`
 	IsPersistentComment bool   `json:"is_persistent_comment"`
 	IsSticky            bool   `json:"is_sticky"`
 	WithServices        bool   `json:"with_services"`
+}
+
+// CreateServiceAcknowledgementRequest is the request body for acknowledging a service.
+type CreateServiceAcknowledgementRequest struct {
+	Comment             string `json:"comment"`
+	IsNotifyContacts    bool   `json:"is_notify_contacts"`
+	IsPersistentComment bool   `json:"is_persistent_comment"`
+	IsSticky            bool   `json:"is_sticky"`
 }
 
 // AcknowledgementService provides access to the acknowledgement endpoints.
@@ -74,12 +82,12 @@ func (s *AcknowledgementService) ListForService(ctx context.Context, hostID, ser
 }
 
 // CreateForHost acknowledges the given host.
-func (s *AcknowledgementService) CreateForHost(ctx context.Context, hostID int, req *CreateAcknowledgementRequest) error {
+func (s *AcknowledgementService) CreateForHost(ctx context.Context, hostID int, req *CreateHostAcknowledgementRequest) error {
 	return s.client.post(ctx, fmt.Sprintf("/monitoring/hosts/%d/acknowledgements", hostID), req, nil)
 }
 
 // CreateForService acknowledges the given service on a host.
-func (s *AcknowledgementService) CreateForService(ctx context.Context, hostID, serviceID int, req *CreateAcknowledgementRequest) error {
+func (s *AcknowledgementService) CreateForService(ctx context.Context, hostID, serviceID int, req *CreateServiceAcknowledgementRequest) error {
 	return s.client.post(ctx, fmt.Sprintf("/monitoring/hosts/%d/services/%d/acknowledgements", hostID, serviceID), req, nil)
 }
 

--- a/acknowledgements_test.go
+++ b/acknowledgements_test.go
@@ -167,7 +167,7 @@ func TestAcknowledgementService_CreateForHost(t *testing.T) {
 	var called bool
 	mux.HandleFunc("POST /centreon/api/latest/monitoring/hosts/10/acknowledgements", func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		var req CreateAcknowledgementRequest
+		var req CreateHostAcknowledgementRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Errorf("decode body: %v", err)
 		}
@@ -183,7 +183,7 @@ func TestAcknowledgementService_CreateForHost(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := c.Acknowledgements.CreateForHost(t.Context(), 10, &CreateAcknowledgementRequest{
+	err := c.Acknowledgements.CreateForHost(t.Context(), 10, &CreateHostAcknowledgementRequest{
 		Comment:             "Acknowledged by operator",
 		IsSticky:            true,
 		IsPersistentComment: true,
@@ -202,7 +202,7 @@ func TestAcknowledgementService_CreateForService(t *testing.T) {
 	var called bool
 	mux.HandleFunc("POST /centreon/api/latest/monitoring/hosts/10/services/5/acknowledgements", func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		var req CreateAcknowledgementRequest
+		var req CreateServiceAcknowledgementRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Errorf("decode body: %v", err)
 		}
@@ -215,7 +215,7 @@ func TestAcknowledgementService_CreateForService(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := c.Acknowledgements.CreateForService(t.Context(), 10, 5, &CreateAcknowledgementRequest{
+	err := c.Acknowledgements.CreateForService(t.Context(), 10, 5, &CreateServiceAcknowledgementRequest{
 		Comment:          "Service acknowledged",
 		IsNotifyContacts: true,
 	})
@@ -241,7 +241,7 @@ func TestAcknowledgementService_CreateForHost_WithServices(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := c.Acknowledgements.CreateForHost(t.Context(), 10, &CreateAcknowledgementRequest{
+	err := c.Acknowledgements.CreateForHost(t.Context(), 10, &CreateHostAcknowledgementRequest{
 		Comment:      "test ack",
 		WithServices: true,
 	})

--- a/contact_groups.go
+++ b/contact_groups.go
@@ -22,7 +22,7 @@ type ContactGroupService struct {
 // List returns a paginated list of contact groups.
 func (s *ContactGroupService) List(ctx context.Context, opts ...ListOption) (*ListResponse[ContactGroup], error) {
 	var resp ListResponse[ContactGroup]
-	err := s.client.list(ctx, "/users/contact-groups", opts, &resp)
+	err := s.client.list(ctx, "/configuration/users/contact-groups", opts, &resp)
 	return &resp, err
 }
 

--- a/contact_groups_test.go
+++ b/contact_groups_test.go
@@ -8,7 +8,7 @@ import (
 func TestContactGroupService_List(t *testing.T) {
 	mux, c := newTestMux(t)
 
-	mux.HandleFunc("GET /centreon/api/latest/users/contact-groups", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /centreon/api/latest/configuration/users/contact-groups", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]any{
 			"result": []map[string]any{
 				{"id": 1, "name": "admins", "alias": "Administrators", "type": "local", "is_activated": true},

--- a/contact_templates.go
+++ b/contact_templates.go
@@ -21,7 +21,7 @@ type ContactTemplateService struct {
 // List returns a paginated list of contact templates.
 func (s *ContactTemplateService) List(ctx context.Context, opts ...ListOption) (*ListResponse[ContactTemplate], error) {
 	var resp ListResponse[ContactTemplate]
-	err := s.client.list(ctx, "/users/contact-templates", opts, &resp)
+	err := s.client.list(ctx, "/configuration/users/contact-templates", opts, &resp)
 	return &resp, err
 }
 

--- a/contact_templates_test.go
+++ b/contact_templates_test.go
@@ -8,7 +8,7 @@ import (
 func TestContactTemplateService_List(t *testing.T) {
 	mux, c := newTestMux(t)
 
-	mux.HandleFunc("GET /centreon/api/latest/users/contact-templates", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /centreon/api/latest/configuration/users/contact-templates", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, ListResponse[ContactTemplate]{
 			Result: []ContactTemplate{
 				{ID: 1, Name: "generic-contact", Alias: "Generic Contact", IsActivated: true},

--- a/downtimes.go
+++ b/downtimes.go
@@ -102,12 +102,42 @@ func (s *DowntimeService) CreateForService(ctx context.Context, hostID, serviceI
 	return s.client.post(ctx, fmt.Sprintf("/monitoring/hosts/%d/services/%d/downtimes", hostID, serviceID), req, nil)
 }
 
-// CancelForHost cancels all downtimes for the given host.
+// CancelForHost cancels all active downtimes for the given host.
+// It lists downtimes for the host and cancels each non-cancelled one by ID.
 func (s *DowntimeService) CancelForHost(ctx context.Context, hostID int) error {
-	return s.client.delete(ctx, fmt.Sprintf("/monitoring/hosts/%d/downtimes", hostID))
+	listFn := func(ctx context.Context, opts ...ListOption) (*ListResponse[Downtime], error) {
+		return s.ListForHost(ctx, hostID, opts...)
+	}
+	for dt, err := range all(ctx, listFn, nil) {
+		if err != nil {
+			return fmt.Errorf("list downtimes for host %d: %w", hostID, err)
+		}
+		if dt.IsCancelled {
+			continue
+		}
+		if err := s.Cancel(ctx, dt.ID); err != nil {
+			return fmt.Errorf("cancel downtime %d: %w", dt.ID, err)
+		}
+	}
+	return nil
 }
 
-// CancelForService cancels all downtimes for the given service on a host.
+// CancelForService cancels all active downtimes for the given service on a host.
+// It lists downtimes for the service and cancels each non-cancelled one by ID.
 func (s *DowntimeService) CancelForService(ctx context.Context, hostID, serviceID int) error {
-	return s.client.delete(ctx, fmt.Sprintf("/monitoring/hosts/%d/services/%d/downtimes", hostID, serviceID))
+	listFn := func(ctx context.Context, opts ...ListOption) (*ListResponse[Downtime], error) {
+		return s.ListForService(ctx, hostID, serviceID, opts...)
+	}
+	for dt, err := range all(ctx, listFn, nil) {
+		if err != nil {
+			return fmt.Errorf("list downtimes for host %d service %d: %w", hostID, serviceID, err)
+		}
+		if dt.IsCancelled {
+			continue
+		}
+		if err := s.Cancel(ctx, dt.ID); err != nil {
+			return fmt.Errorf("cancel downtime %d: %w", dt.ID, err)
+		}
+	}
+	return nil
 }

--- a/downtimes.go
+++ b/downtimes.go
@@ -28,14 +28,23 @@ type Downtime struct {
 	IsStarted       bool       `json:"is_started"`
 }
 
-// CreateDowntimeRequest is the request body for scheduling a downtime on a host or service.
-type CreateDowntimeRequest struct {
+// CreateHostDowntimeRequest is the request body for scheduling a downtime on a host.
+type CreateHostDowntimeRequest struct {
 	Comment      string    `json:"comment"`
 	StartTime    time.Time `json:"start_time"`
 	EndTime      time.Time `json:"end_time"`
 	IsFixed      bool      `json:"is_fixed"`
 	Duration     int       `json:"duration"`
 	WithServices bool      `json:"with_services"`
+}
+
+// CreateServiceDowntimeRequest is the request body for scheduling a downtime on a service.
+type CreateServiceDowntimeRequest struct {
+	Comment   string    `json:"comment"`
+	StartTime time.Time `json:"start_time"`
+	EndTime   time.Time `json:"end_time"`
+	IsFixed   bool      `json:"is_fixed"`
+	Duration  int       `json:"duration"`
 }
 
 // DowntimeService provides access to the downtime endpoints.
@@ -84,12 +93,12 @@ func (s *DowntimeService) ListForService(ctx context.Context, hostID, serviceID 
 }
 
 // CreateForHost schedules a downtime for the given host.
-func (s *DowntimeService) CreateForHost(ctx context.Context, hostID int, req *CreateDowntimeRequest) error {
+func (s *DowntimeService) CreateForHost(ctx context.Context, hostID int, req *CreateHostDowntimeRequest) error {
 	return s.client.post(ctx, fmt.Sprintf("/monitoring/hosts/%d/downtimes", hostID), req, nil)
 }
 
 // CreateForService schedules a downtime for the given service on a host.
-func (s *DowntimeService) CreateForService(ctx context.Context, hostID, serviceID int, req *CreateDowntimeRequest) error {
+func (s *DowntimeService) CreateForService(ctx context.Context, hostID, serviceID int, req *CreateServiceDowntimeRequest) error {
 	return s.client.post(ctx, fmt.Sprintf("/monitoring/hosts/%d/services/%d/downtimes", hostID, serviceID), req, nil)
 }
 

--- a/downtimes_test.go
+++ b/downtimes_test.go
@@ -400,33 +400,87 @@ func TestDowntimeService_CreateForHost_WithServices(t *testing.T) {
 func TestDowntimeService_CancelForHost(t *testing.T) {
 	mux, c := newTestMux(t)
 
-	var called bool
-	mux.HandleFunc("DELETE /centreon/api/latest/monitoring/hosts/10/downtimes", func(w http.ResponseWriter, r *http.Request) {
-		called = true
+	var cancelledIDs []string
+
+	// List endpoint returns 2 downtimes (1 active, 1 already cancelled)
+	mux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/10/downtimes", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"result": []map[string]any{
+				{"id": 1, "host_id": 10, "comment": "dt1", "is_fixed": true,
+					"start_time": "2024-01-15T08:00:00Z", "end_time": "2024-01-15T10:00:00Z",
+					"duration": 7200, "poller_id": 1, "is_cancelled": false, "is_started": true,
+					"author_name": "admin"},
+				{"id": 2, "host_id": 10, "comment": "dt2", "is_fixed": true,
+					"start_time": "2024-01-15T08:00:00Z", "end_time": "2024-01-15T10:00:00Z",
+					"duration": 7200, "poller_id": 1, "is_cancelled": true, "is_started": false,
+					"author_name": "admin"},
+			},
+			"meta": map[string]any{"page": 1, "limit": 10, "total": 2},
+		})
+	})
+
+	// Cancel endpoint — only downtime 1 should be cancelled (2 is already cancelled)
+	mux.HandleFunc("DELETE /centreon/api/latest/monitoring/downtimes/1", func(w http.ResponseWriter, r *http.Request) {
+		cancelledIDs = append(cancelledIDs, "1")
 		w.WriteHeader(http.StatusNoContent)
 	})
 
 	if err := c.Downtimes.CancelForHost(t.Context(), 10); err != nil {
 		t.Fatalf("CancelForHost: %v", err)
 	}
-	if !called {
-		t.Error("handler was not called")
+	if len(cancelledIDs) != 1 {
+		t.Fatalf("cancelled %d downtimes, want 1", len(cancelledIDs))
+	}
+	if cancelledIDs[0] != "1" {
+		t.Errorf("cancelled ID = %q, want %q", cancelledIDs[0], "1")
 	}
 }
 
 func TestDowntimeService_CancelForService(t *testing.T) {
 	mux, c := newTestMux(t)
 
-	var called bool
-	mux.HandleFunc("DELETE /centreon/api/latest/monitoring/hosts/10/services/5/downtimes", func(w http.ResponseWriter, r *http.Request) {
-		called = true
+	var cancelledIDs []string
+
+	mux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/10/services/5/downtimes", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"result": []map[string]any{
+				{"id": 3, "host_id": 10, "service_id": 5, "comment": "svc dt",
+					"is_fixed": true, "start_time": "2024-01-15T08:00:00Z",
+					"end_time": "2024-01-15T10:00:00Z", "duration": 3600,
+					"poller_id": 1, "is_cancelled": false, "is_started": true,
+					"author_name": "admin"},
+			},
+			"meta": map[string]any{"page": 1, "limit": 10, "total": 1},
+		})
+	})
+
+	mux.HandleFunc("DELETE /centreon/api/latest/monitoring/downtimes/3", func(w http.ResponseWriter, r *http.Request) {
+		cancelledIDs = append(cancelledIDs, "3")
 		w.WriteHeader(http.StatusNoContent)
 	})
 
 	if err := c.Downtimes.CancelForService(t.Context(), 10, 5); err != nil {
 		t.Fatalf("CancelForService: %v", err)
 	}
-	if !called {
-		t.Error("handler was not called")
+	if len(cancelledIDs) != 1 {
+		t.Fatalf("cancelled %d downtimes, want 1", len(cancelledIDs))
+	}
+	if cancelledIDs[0] != "3" {
+		t.Errorf("cancelled ID = %q, want %q", cancelledIDs[0], "3")
+	}
+}
+
+func TestDowntimeService_CancelForHost_NoneActive(t *testing.T) {
+	mux, c := newTestMux(t)
+
+	mux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/10/downtimes", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"result": []map[string]any{},
+			"meta":   map[string]any{"page": 1, "limit": 10, "total": 0},
+		})
+	})
+
+	if err := c.Downtimes.CancelForHost(t.Context(), 10); err != nil {
+		t.Fatalf("CancelForHost: %v", err)
 	}
 }

--- a/downtimes_test.go
+++ b/downtimes_test.go
@@ -291,7 +291,7 @@ func TestDowntimeService_CreateForHost(t *testing.T) {
 
 	mux.HandleFunc("POST /centreon/api/latest/monitoring/hosts/10/downtimes", func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		var req CreateDowntimeRequest
+		var req CreateHostDowntimeRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode body: %v", err)
 		}
@@ -310,7 +310,7 @@ func TestDowntimeService_CreateForHost(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := c.Downtimes.CreateForHost(t.Context(), 10, &CreateDowntimeRequest{
+	err := c.Downtimes.CreateForHost(t.Context(), 10, &CreateHostDowntimeRequest{
 		Comment:   "Host maintenance",
 		StartTime: start,
 		EndTime:   end,
@@ -334,7 +334,7 @@ func TestDowntimeService_CreateForService(t *testing.T) {
 
 	mux.HandleFunc("POST /centreon/api/latest/monitoring/hosts/10/services/5/downtimes", func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		var req CreateDowntimeRequest
+		var req CreateServiceDowntimeRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode body: %v", err)
 		}
@@ -356,7 +356,7 @@ func TestDowntimeService_CreateForService(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := c.Downtimes.CreateForService(t.Context(), 10, 5, &CreateDowntimeRequest{
+	err := c.Downtimes.CreateForService(t.Context(), 10, 5, &CreateServiceDowntimeRequest{
 		Comment:   "Service maintenance",
 		StartTime: start,
 		EndTime:   end,
@@ -385,7 +385,7 @@ func TestDowntimeService_CreateForHost_WithServices(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := c.Downtimes.CreateForHost(t.Context(), 10, &CreateDowntimeRequest{
+	err := c.Downtimes.CreateForHost(t.Context(), 10, &CreateHostDowntimeRequest{
 		Comment:      "test",
 		StartTime:    time.Now(),
 		EndTime:      time.Now().Add(time.Hour),

--- a/operations.go
+++ b/operations.go
@@ -9,41 +9,41 @@ import (
 type ResourceRef struct {
 	Type   string       `json:"type"` // "host" or "service"
 	ID     int          `json:"id"`
-	Parent *ResourceRef `json:"parent,omitempty"`
+	Parent *ResourceRef `json:"parent"`
 }
 
 // AcknowledgeRequest is the request body for acknowledging resources.
 type AcknowledgeRequest struct {
-	Resources           []ResourceRef `json:"resources"`
-	Comment             string        `json:"comment"`
-	IsNotifyContacts    bool          `json:"is_notify_contacts"`
-	IsPersistentComment bool          `json:"is_persistent_comment"`
-	IsSticky            bool          `json:"is_sticky"`
+	Resources           []ResourceRef
+	Comment             string
+	IsNotifyContacts    bool
+	IsPersistentComment bool
+	IsSticky            bool
 }
 
 // DowntimeRequest is the request body for scheduling downtime on resources.
 type DowntimeRequest struct {
-	Resources []ResourceRef `json:"resources"`
-	Comment   string        `json:"comment"`
-	StartTime time.Time     `json:"start_time"`
-	EndTime   time.Time     `json:"end_time"`
-	Fixed     bool          `json:"is_fixed"`
-	Duration  int           `json:"duration"`
+	Resources []ResourceRef
+	Comment   string
+	StartTime time.Time
+	EndTime   time.Time
+	Fixed     bool
+	Duration  int
 }
 
 // CheckRequest is the request body for forcing checks on resources.
 type CheckRequest struct {
-	Resources []ResourceRef `json:"resources"`
+	Resources []ResourceRef
 }
 
 // SubmitResource is a single resource result to submit.
 type SubmitResource struct {
 	Type     string       `json:"type"`
 	ID       int          `json:"id"`
-	Parent   *ResourceRef `json:"parent,omitempty"`
+	Parent   *ResourceRef `json:"parent"`
 	Status   int          `json:"status"`
 	Output   string       `json:"output"`
-	PerfData string       `json:"performance_data,omitzero"`
+	PerfData string       `json:"performance_data,omitempty"`
 }
 
 // SubmitResultRequest is the request body for submitting check results.
@@ -53,8 +53,52 @@ type SubmitResultRequest struct {
 
 // CommentRequest is the request body for adding comments to resources.
 type CommentRequest struct {
+	Resources []ResourceRef
+	Comment   string
+}
+
+// Wire-format types for JSON serialization.
+
+type acknowledgeBody struct {
+	Resources       []ResourceRef    `json:"resources"`
+	Acknowledgement acknowledgeParam `json:"acknowledgement"`
+}
+type acknowledgeParam struct {
+	Comment             string `json:"comment"`
+	IsNotifyContacts    bool   `json:"is_notify_contacts"`
+	IsPersistentComment bool   `json:"is_persistent_comment"`
+	IsSticky            bool   `json:"is_sticky"`
+}
+
+type downtimeBody struct {
 	Resources []ResourceRef `json:"resources"`
-	Comment   string        `json:"comment"`
+	Downtime  downtimeParam `json:"downtime"`
+}
+type downtimeParam struct {
+	Comment   string    `json:"comment"`
+	StartTime time.Time `json:"start_time"`
+	EndTime   time.Time `json:"end_time"`
+	IsFixed   bool      `json:"is_fixed"`
+	Duration  int       `json:"duration"`
+}
+
+type checkBody struct {
+	Resources []ResourceRef `json:"resources"`
+	Check     checkParam    `json:"check"`
+}
+type checkParam struct {
+	IsForced bool `json:"is_forced"`
+}
+
+type commentResource struct {
+	Type    string       `json:"type"`
+	ID      int          `json:"id"`
+	Parent  *ResourceRef `json:"parent"`
+	Comment string       `json:"comment"`
+	Date    time.Time    `json:"date"`
+}
+type commentBody struct {
+	Resources []commentResource `json:"resources"`
 }
 
 // OperationsService provides monitoring operations (acknowledge, downtime, check, submit, comment).
@@ -64,17 +108,40 @@ type OperationsService struct {
 
 // Acknowledge acknowledges one or more resources.
 func (s *OperationsService) Acknowledge(ctx context.Context, req *AcknowledgeRequest) error {
-	return s.client.post(ctx, "/monitoring/resources/acknowledge", req, nil)
+	body := acknowledgeBody{
+		Resources: req.Resources,
+		Acknowledgement: acknowledgeParam{
+			Comment:             req.Comment,
+			IsNotifyContacts:    req.IsNotifyContacts,
+			IsPersistentComment: req.IsPersistentComment,
+			IsSticky:            req.IsSticky,
+		},
+	}
+	return s.client.post(ctx, "/monitoring/resources/acknowledge", body, nil)
 }
 
 // Downtime schedules downtime for one or more resources.
 func (s *OperationsService) Downtime(ctx context.Context, req *DowntimeRequest) error {
-	return s.client.post(ctx, "/monitoring/resources/downtime", req, nil)
+	body := downtimeBody{
+		Resources: req.Resources,
+		Downtime: downtimeParam{
+			Comment:   req.Comment,
+			StartTime: req.StartTime,
+			EndTime:   req.EndTime,
+			IsFixed:   req.Fixed,
+			Duration:  req.Duration,
+		},
+	}
+	return s.client.post(ctx, "/monitoring/resources/downtime", body, nil)
 }
 
 // Check forces an immediate check for one or more resources.
 func (s *OperationsService) Check(ctx context.Context, req *CheckRequest) error {
-	return s.client.post(ctx, "/monitoring/resources/check", req, nil)
+	body := checkBody{
+		Resources: req.Resources,
+		Check:     checkParam{IsForced: true},
+	}
+	return s.client.post(ctx, "/monitoring/resources/check", body, nil)
 }
 
 // Submit submits passive check results for one or more resources.
@@ -84,5 +151,16 @@ func (s *OperationsService) Submit(ctx context.Context, req *SubmitResultRequest
 
 // Comment adds a comment to one or more resources.
 func (s *OperationsService) Comment(ctx context.Context, req *CommentRequest) error {
-	return s.client.post(ctx, "/monitoring/resources/comments", req, nil)
+	now := time.Now()
+	resources := make([]commentResource, len(req.Resources))
+	for i, r := range req.Resources {
+		resources[i] = commentResource{
+			Type:    r.Type,
+			ID:      r.ID,
+			Parent:  r.Parent,
+			Comment: req.Comment,
+			Date:    now,
+		}
+	}
+	return s.client.post(ctx, "/monitoring/resources/comments", commentBody{Resources: resources}, nil)
 }

--- a/operations_test.go
+++ b/operations_test.go
@@ -7,31 +7,65 @@ import (
 	"time"
 )
 
+// decodeBody decodes a JSON request body into a map and returns it.
+func decodeBody(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+	var body map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	return body
+}
+
+// resourceAt extracts resource at index i from the body's "resources" array.
+func resourceAt(t *testing.T, body map[string]any, i int) map[string]any {
+	t.Helper()
+	resources, ok := body["resources"].([]any)
+	if !ok || len(resources) <= i {
+		t.Fatalf("resources = %v, want array with at least %d elements", body["resources"], i+1)
+	}
+	res, ok := resources[i].(map[string]any)
+	if !ok {
+		t.Fatalf("resources[%d] is not an object", i)
+	}
+	return res
+}
+
+// requireNullParent checks that a resource has "parent": null (present but nil).
+func requireNullParent(t *testing.T, res map[string]any, label string) {
+	t.Helper()
+	if _, hasParent := res["parent"]; !hasParent {
+		t.Errorf("%s.parent is missing, want explicit null", label)
+	}
+	if res["parent"] != nil {
+		t.Errorf("%s.parent = %v, want null", label, res["parent"])
+	}
+}
+
 func TestOperationsService_Acknowledge(t *testing.T) {
 	mux, c := newTestMux(t)
 
 	var called bool
 	mux.HandleFunc("POST /centreon/api/latest/monitoring/resources/acknowledge", func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		var req AcknowledgeRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Errorf("decode body: %v", err)
+		body := decodeBody(t, r)
+		res := resourceAt(t, body, 0)
+		if res["type"] != "host" {
+			t.Errorf("resources[0].type = %v, want host", res["type"])
 		}
-		if len(req.Resources) != 1 {
-			t.Fatalf("len(Resources) = %d, want 1", len(req.Resources))
+		requireNullParent(t, res, "resources[0]")
+
+		ack, ok := body["acknowledgement"].(map[string]any)
+		if !ok {
+			t.Fatalf("acknowledgement wrapper missing, got body: %v", body)
 		}
-		if req.Resources[0].Type != "host" {
-			t.Errorf("Resources[0].Type = %q, want %q", req.Resources[0].Type, "host")
+		if ack["comment"] != "Acknowledged by operator" {
+			t.Errorf("acknowledgement.comment = %v, want %q", ack["comment"], "Acknowledged by operator")
 		}
-		if req.Resources[0].ID != 42 {
-			t.Errorf("Resources[0].ID = %d, want 42", req.Resources[0].ID)
+		if ack["is_sticky"] != true {
+			t.Error("acknowledgement.is_sticky should be true")
 		}
-		if req.Comment != "Acknowledged by operator" {
-			t.Errorf("Comment = %q, want %q", req.Comment, "Acknowledged by operator")
-		}
-		if !req.IsSticky {
-			t.Error("IsSticky should be true")
-		}
+
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -59,19 +93,23 @@ func TestOperationsService_Downtime(t *testing.T) {
 	var called bool
 	mux.HandleFunc("POST /centreon/api/latest/monitoring/resources/downtime", func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		var req DowntimeRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Errorf("decode body: %v", err)
+		body := decodeBody(t, r)
+		for i := range 2 {
+			res := resourceAt(t, body, i)
+			requireNullParent(t, res, "resources[0]")
 		}
-		if len(req.Resources) != 2 {
-			t.Errorf("len(Resources) = %d, want 2", len(req.Resources))
+
+		dt, ok := body["downtime"].(map[string]any)
+		if !ok {
+			t.Fatalf("downtime wrapper missing, got body: %v", body)
 		}
-		if req.Comment != "Maintenance window" {
-			t.Errorf("Comment = %q, want %q", req.Comment, "Maintenance window")
+		if dt["comment"] != "Maintenance window" {
+			t.Errorf("downtime.comment = %v, want %q", dt["comment"], "Maintenance window")
 		}
-		if !req.Fixed {
-			t.Error("Fixed should be true")
+		if dt["is_fixed"] != true {
+			t.Error("downtime.is_fixed should be true")
 		}
+
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -99,22 +137,23 @@ func TestOperationsService_Check(t *testing.T) {
 	var called bool
 	mux.HandleFunc("POST /centreon/api/latest/monitoring/resources/check", func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		var req CheckRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Errorf("decode body: %v", err)
+		body := decodeBody(t, r)
+		res := resourceAt(t, body, 0)
+		if res["type"] != "service" {
+			t.Errorf("resources[0].type = %v, want service", res["type"])
 		}
-		if len(req.Resources) != 1 {
-			t.Fatalf("len(Resources) = %d, want 1", len(req.Resources))
+		parent, ok := res["parent"].(map[string]any)
+		if !ok {
+			t.Fatal("resources[0].parent is not an object")
 		}
-		if req.Resources[0].Type != "service" {
-			t.Errorf("Resources[0].Type = %q, want %q", req.Resources[0].Type, "service")
+		if parent["id"] != float64(3) {
+			t.Errorf("resources[0].parent.id = %v, want 3", parent["id"])
 		}
-		if req.Resources[0].ID != 7 {
-			t.Errorf("Resources[0].ID = %d, want 7", req.Resources[0].ID)
+
+		if _, ok := body["check"]; !ok {
+			t.Fatal("check wrapper missing")
 		}
-		if req.Resources[0].Parent == nil || req.Resources[0].Parent.ID != 3 {
-			t.Errorf("Resources[0].Parent.ID should be 3")
-		}
+
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -137,26 +176,25 @@ func TestOperationsService_Submit(t *testing.T) {
 	var called bool
 	mux.HandleFunc("POST /centreon/api/latest/monitoring/resources/submit", func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		var req SubmitResultRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Errorf("decode body: %v", err)
+		body := decodeBody(t, r)
+		res := resourceAt(t, body, 0)
+		if res["type"] != "service" {
+			t.Errorf("type = %v, want service", res["type"])
 		}
-		if len(req.Resources) != 1 {
-			t.Fatalf("len(Resources) = %d, want 1", len(req.Resources))
+		if res["output"] != "All systems nominal" {
+			t.Errorf("output = %v, want %q", res["output"], "All systems nominal")
 		}
-		res := req.Resources[0]
-		if res.Type != "service" {
-			t.Errorf("Resources[0].Type = %q, want %q", res.Type, "service")
+		if res["performance_data"] != "rta=1ms" {
+			t.Errorf("performance_data = %v, want %q", res["performance_data"], "rta=1ms")
 		}
-		if res.Status != 0 {
-			t.Errorf("Resources[0].Status = %d, want 0", res.Status)
+		parent, ok := res["parent"].(map[string]any)
+		if !ok {
+			t.Fatal("resources[0].parent is not an object")
 		}
-		if res.Output != "All systems nominal" {
-			t.Errorf("Resources[0].Output = %q, want %q", res.Output, "All systems nominal")
+		if parent["id"] != float64(1) {
+			t.Errorf("parent.id = %v, want 1", parent["id"])
 		}
-		if res.PerfData != "rta=1ms" {
-			t.Errorf("Resources[0].PerfData = %q, want %q", res.PerfData, "rta=1ms")
-		}
+
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -186,22 +224,19 @@ func TestOperationsService_Comment(t *testing.T) {
 	var called bool
 	mux.HandleFunc("POST /centreon/api/latest/monitoring/resources/comments", func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		var req CommentRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Errorf("decode body: %v", err)
+		body := decodeBody(t, r)
+		res := resourceAt(t, body, 0)
+		if res["type"] != "host" {
+			t.Errorf("type = %v, want host", res["type"])
 		}
-		if len(req.Resources) != 1 {
-			t.Fatalf("len(Resources) = %d, want 1", len(req.Resources))
+		if res["comment"] != "Under investigation" {
+			t.Errorf("comment = %v, want %q", res["comment"], "Under investigation")
 		}
-		if req.Resources[0].Type != "host" {
-			t.Errorf("Resources[0].Type = %q, want %q", req.Resources[0].Type, "host")
+		requireNullParent(t, res, "resources[0]")
+		if _, hasDate := res["date"]; !hasDate {
+			t.Error("date is missing, want timestamp")
 		}
-		if req.Resources[0].ID != 10 {
-			t.Errorf("Resources[0].ID = %d, want 10", req.Resources[0].ID)
-		}
-		if req.Comment != "Under investigation" {
-			t.Errorf("Comment = %q, want %q", req.Comment, "Under investigation")
-		}
+
 		w.WriteHeader(http.StatusNoContent)
 	})
 

--- a/operations_test.go
+++ b/operations_test.go
@@ -150,8 +150,12 @@ func TestOperationsService_Check(t *testing.T) {
 			t.Errorf("resources[0].parent.id = %v, want 3", parent["id"])
 		}
 
-		if _, ok := body["check"]; !ok {
+		check, ok := body["check"].(map[string]any)
+		if !ok {
 			t.Fatal("check wrapper missing")
+		}
+		if check["is_forced"] != true {
+			t.Errorf("check.is_forced = %v, want true", check["is_forced"])
 		}
 
 		w.WriteHeader(http.StatusNoContent)

--- a/user_filters.go
+++ b/user_filters.go
@@ -46,7 +46,7 @@ type UserFilterService struct {
 // List returns a paginated list of user filters.
 func (s *UserFilterService) List(ctx context.Context, opts ...ListOption) (*ListResponse[UserFilter], error) {
 	var resp ListResponse[UserFilter]
-	err := s.client.list(ctx, "/users/filters", opts, &resp)
+	err := s.client.list(ctx, "/configuration/users/filters", opts, &resp)
 	return &resp, err
 }
 
@@ -58,7 +58,7 @@ func (s *UserFilterService) All(ctx context.Context, opts ...ListOption) iter.Se
 // Get returns the user filter with the given ID.
 func (s *UserFilterService) Get(ctx context.Context, id int) (*UserFilter, error) {
 	var uf UserFilter
-	if err := s.client.get(ctx, fmt.Sprintf("/users/filters/%d", id), &uf); err != nil {
+	if err := s.client.get(ctx, fmt.Sprintf("/configuration/users/filters/%d", id), &uf); err != nil {
 		return nil, err
 	}
 	return &uf, nil
@@ -69,7 +69,7 @@ func (s *UserFilterService) Create(ctx context.Context, req CreateUserFilterRequ
 	var result struct {
 		ID int `json:"id"`
 	}
-	if err := s.client.post(ctx, "/users/filters", req, &result); err != nil {
+	if err := s.client.post(ctx, "/configuration/users/filters", req, &result); err != nil {
 		return 0, err
 	}
 	return result.ID, nil
@@ -77,15 +77,15 @@ func (s *UserFilterService) Create(ctx context.Context, req CreateUserFilterRequ
 
 // Update replaces an existing user filter using PUT.
 func (s *UserFilterService) Update(ctx context.Context, id int, req UpdateUserFilterRequest) error {
-	return s.client.put(ctx, fmt.Sprintf("/users/filters/%d", id), req)
+	return s.client.put(ctx, fmt.Sprintf("/configuration/users/filters/%d", id), req)
 }
 
 // Patch partially updates an existing user filter using PATCH.
 func (s *UserFilterService) Patch(ctx context.Context, id int, req PatchUserFilterRequest) error {
-	return s.client.patch(ctx, fmt.Sprintf("/users/filters/%d", id), req)
+	return s.client.patch(ctx, fmt.Sprintf("/configuration/users/filters/%d", id), req)
 }
 
 // Delete deletes a user filter by ID.
 func (s *UserFilterService) Delete(ctx context.Context, id int) error {
-	return s.client.delete(ctx, fmt.Sprintf("/users/filters/%d", id))
+	return s.client.delete(ctx, fmt.Sprintf("/configuration/users/filters/%d", id))
 }

--- a/user_filters_test.go
+++ b/user_filters_test.go
@@ -9,7 +9,7 @@ import (
 func TestUserFilterService_List(t *testing.T) {
 	mux, c := newTestMux(t)
 
-	mux.HandleFunc("GET /centreon/api/latest/users/filters", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /centreon/api/latest/configuration/users/filters", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, ListResponse[UserFilter]{
 			Result: []UserFilter{
 				{ID: 1, Name: "my-filter"},
@@ -34,7 +34,7 @@ func TestUserFilterService_List(t *testing.T) {
 func TestUserFilterService_Get(t *testing.T) {
 	mux, c := newTestMux(t)
 
-	mux.HandleFunc("GET /centreon/api/latest/users/filters/3", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /centreon/api/latest/configuration/users/filters/3", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, UserFilter{
 			ID:   3,
 			Name: "test-filter",
@@ -65,7 +65,7 @@ func TestUserFilterService_Get(t *testing.T) {
 func TestUserFilterService_Create(t *testing.T) {
 	mux, c := newTestMux(t)
 
-	mux.HandleFunc("POST /centreon/api/latest/users/filters", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("POST /centreon/api/latest/configuration/users/filters", func(w http.ResponseWriter, r *http.Request) {
 		var req CreateUserFilterRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode body: %v", err)
@@ -90,7 +90,7 @@ func TestUserFilterService_Create(t *testing.T) {
 func TestUserFilterService_Update(t *testing.T) {
 	mux, c := newTestMux(t)
 
-	mux.HandleFunc("PUT /centreon/api/latest/users/filters/3", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("PUT /centreon/api/latest/configuration/users/filters/3", func(w http.ResponseWriter, r *http.Request) {
 		var req UpdateUserFilterRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode body: %v", err)
@@ -110,7 +110,7 @@ func TestUserFilterService_Update(t *testing.T) {
 func TestUserFilterService_Patch(t *testing.T) {
 	mux, c := newTestMux(t)
 
-	mux.HandleFunc("PATCH /centreon/api/latest/users/filters/3", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("PATCH /centreon/api/latest/configuration/users/filters/3", func(w http.ResponseWriter, r *http.Request) {
 		var req PatchUserFilterRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode body: %v", err)
@@ -132,7 +132,7 @@ func TestUserFilterService_Delete(t *testing.T) {
 	mux, c := newTestMux(t)
 
 	var called bool
-	mux.HandleFunc("DELETE /centreon/api/latest/users/filters/3", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("DELETE /centreon/api/latest/configuration/users/filters/3", func(w http.ResponseWriter, r *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/users.go
+++ b/users.go
@@ -31,7 +31,7 @@ type UserService struct {
 // List returns a paginated list of users.
 func (s *UserService) List(ctx context.Context, opts ...ListOption) (*ListResponse[User], error) {
 	var resp ListResponse[User]
-	err := s.client.list(ctx, "/users", opts, &resp)
+	err := s.client.list(ctx, "/configuration/users", opts, &resp)
 	return &resp, err
 }
 
@@ -42,5 +42,5 @@ func (s *UserService) All(ctx context.Context, opts ...ListOption) iter.Seq2[*Us
 
 // Update updates an existing user using PATCH.
 func (s *UserService) Update(ctx context.Context, id int, req UpdateUserRequest) error {
-	return s.client.patch(ctx, fmt.Sprintf("/users/%d", id), req)
+	return s.client.patch(ctx, fmt.Sprintf("/configuration/users/%d", id), req)
 }

--- a/users_test.go
+++ b/users_test.go
@@ -9,7 +9,7 @@ import (
 func TestUserService_List(t *testing.T) {
 	mux, c := newTestMux(t)
 
-	mux.HandleFunc("GET /centreon/api/latest/users", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /centreon/api/latest/configuration/users", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]any{
 			"result": []map[string]any{
 				{"id": 1, "name": "admin", "alias": "Administrator", "email": "admin@example.com", "is_admin": true},
@@ -43,7 +43,7 @@ func TestUserService_List(t *testing.T) {
 func TestUserService_Update(t *testing.T) {
 	mux, c := newTestMux(t)
 
-	mux.HandleFunc("PATCH /centreon/api/latest/users/5", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("PATCH /centreon/api/latest/configuration/users/5", func(w http.ResponseWriter, r *http.Request) {
 		var req UpdateUserRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Errorf("decode body: %v", err)


### PR DESCRIPTION
## Summary

Fixes 4 bugs that prevented the client from working against a live Centreon instance:

- **#28** — Add `/configuration/` prefix to all user/contact endpoint paths (were returning 404)
- **#26** — Restructure all 5 resource operation payloads to use wrapper objects (`acknowledgement`, `downtime`, `check`) and per-resource `comment`+`date` as the Centreon API expects. Fix `ResourceRef.Parent` to always serialize (`null` for hosts, not omitted)
- **#27** — Split `CreateAcknowledgementRequest` and `CreateDowntimeRequest` into host/service variants so `with_services` is only sent for host endpoints (was causing HTTP 500 on service endpoints)
- **#29** — Replace `DELETE` on per-host/service downtime endpoints with composite list-then-cancel pattern (API only supports POST/GET on those paths)

15 files changed, 357 insertions, 139 deletions.

## Test plan

- [x] All 131 unit tests pass (`go test -count=1 ./...`)
- [x] 0 lint issues (`golangci-lint run ./...`)
- [x] Operations tests verify exact wire format via `map[string]any` JSON decoding
- [x] Downtime cancel tests verify list-then-cancel pattern (skips already-cancelled)
- [x] Gemini peer review: no issues found
- [ ] Integration test against live Centreon instance (#13)

Closes #26, closes #27, closes #28, closes #29