### PR TITLE
feat: read host and service custom macros via Centreon 25.10 detail GET

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ func main() {
 
 | Resource | List | Get | Create | Update | Delete |
 |----------|------|-----|--------|--------|--------|
-| Hosts | yes | by ID* | yes | PATCH | yes |
+| Hosts | yes | yes** / by ID* | yes | PATCH | yes |
 | Host Groups | yes | yes | yes | PUT | yes |
 | Host Categories | yes | yes | yes | PUT | yes |
 | Host Severities | yes | yes | yes | PUT | yes |
 | Host Templates | yes | by ID* | yes | PATCH | yes |
-| Services | yes | by ID* | yes | PATCH | yes |
+| Services | yes | yes** | yes | PATCH | yes |
 | Service Groups | yes | - | yes | - | yes |
 | Service Categories | yes | - | yes | - | yes |
 | Service Severities | yes | - | yes | PUT | yes |
@@ -80,6 +80,8 @@ func main() {
 | Monitoring Servers | yes | - | - | - | - |
 
 *\* by ID = filtered list lookup (API has no direct GET endpoint)*
+
+*\*\* `Get(ctx, id)` requires Centreon 25.10+ and returns the full configuration including custom macros (hosts: macros defined directly on the host; services: also includes macros inherited from service templates and commands). Earlier versions have no single-resource GET route and return an API error with HTTP status 404: on those versions use `GetByID` for hosts, and `ListByHost` for services (the services endpoint has no by-id lookup).*
 
 ### User & Contact Management
 

--- a/example_test.go
+++ b/example_test.go
@@ -122,6 +122,33 @@ func ExampleHostService_Update() {
 	}
 }
 
+func ExampleHostService_Get() {
+	ctx := context.Background()
+	client, _ := centreon.NewClient("https://centreon.example.com",
+		centreon.WithAPIToken("token"),
+	)
+
+	// Get returns the full host configuration including custom macros.
+	// Requires Centreon 25.10 or later; older versions return HTTP 404.
+	host, err := client.Hosts.Get(ctx, 42)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, m := range host.Macros {
+		// Value is nil for password macros, which the API masks on read.
+		if m.IsPassword {
+			fmt.Printf("%s = (password)\n", m.Name)
+			continue
+		}
+		value := ""
+		if m.Value != nil {
+			value = *m.Value
+		}
+		fmt.Printf("%s = %s\n", m.Name, value)
+	}
+}
+
 func ExampleAnd() {
 	// Complex search: prod hosts in a specific address range
 	filter := centreon.And(

--- a/hosts.go
+++ b/hosts.go
@@ -14,6 +14,17 @@ type Macro struct {
 	Description string `json:"description,omitzero"`
 }
 
+// HostMacro is a custom macro as returned by HostService.Get
+// (GET /configuration/hosts/{id}) on Centreon 25.10+. Value is nil when
+// IsPassword is true because the API masks password values on read.
+type HostMacro struct {
+	ID          int     `json:"id"`
+	Name        string  `json:"name"`
+	Value       *string `json:"value"`
+	IsPassword  bool    `json:"is_password"`
+	Description string  `json:"description,omitzero"`
+}
+
 // NamedRef is a lightweight reference to a named Centreon resource.
 // The Centreon API uses {"id": N, "name": "..."} objects for relationships
 // such as templates, categories, groups, and monitoring servers.
@@ -38,6 +49,74 @@ type Host struct {
 	Categories          []NamedRef `json:"categories,omitzero"`
 	Groups              []NamedRef `json:"groups,omitzero"`
 	IsActivated         bool       `json:"is_activated"`
+}
+
+// HostDetail is the full host configuration returned by HostService.Get
+// (GET /configuration/hosts/{id}), including custom macros.
+//
+// This endpoint requires Centreon 25.10 or later; earlier versions have no
+// GET route for a single host and return an *APIError with HTTP status 404
+// (use GetByID for a version-independent, macro-free lookup). Unlike Host
+// (the list shape), references other than categories, groups and templates
+// are raw IDs. Per the Centreon 25.10 API, Macros lists only macros defined
+// directly on the host; macros inherited from parent templates or commands
+// are not returned.
+type HostDetail struct {
+	ID                 int    `json:"id"`
+	MonitoringServerID int    `json:"monitoring_server_id"`
+	Name               string `json:"name"`
+	Address            string `json:"address"`
+	Alias              string `json:"alias,omitzero"`
+
+	SNMPVersion   string `json:"snmp_version,omitzero"`
+	SNMPCommunity string `json:"snmp_community,omitzero"`
+
+	GeoCoords  string `json:"geo_coords,omitzero"`
+	TimezoneID *int   `json:"timezone_id"`
+	SeverityID *int   `json:"severity_id"`
+
+	CheckCommandID      *int     `json:"check_command_id"`
+	CheckCommandArgs    []string `json:"check_command_args,omitzero"`
+	CheckTimeperiodID   *int     `json:"check_timeperiod_id"`
+	MaxCheckAttempts    *int     `json:"max_check_attempts"`
+	NormalCheckInterval *int     `json:"normal_check_interval"`
+	RetryCheckInterval  *int     `json:"retry_check_interval"`
+	ActiveCheckEnabled  int      `json:"active_check_enabled"`
+	PassiveCheckEnabled int      `json:"passive_check_enabled"`
+
+	NotificationEnabled       int  `json:"notification_enabled"`
+	NotificationOptions       *int `json:"notification_options"`
+	NotificationInterval      *int `json:"notification_interval"`
+	NotificationTimeperiodID  *int `json:"notification_timeperiod_id"`
+	AddInheritedContactGroup  bool `json:"add_inherited_contact_group"`
+	AddInheritedContact       bool `json:"add_inherited_contact"`
+	FirstNotificationDelay    *int `json:"first_notification_delay"`
+	RecoveryNotificationDelay *int `json:"recovery_notification_delay"`
+	AcknowledgementTimeout    *int `json:"acknowledgement_timeout"`
+
+	FreshnessChecked   int  `json:"freshness_checked"`
+	FreshnessThreshold *int `json:"freshness_threshold"`
+
+	FlapDetectionEnabled int  `json:"flap_detection_enabled"`
+	LowFlapThreshold     *int `json:"low_flap_threshold"`
+	HighFlapThreshold    *int `json:"high_flap_threshold"`
+
+	EventHandlerEnabled     int      `json:"event_handler_enabled"`
+	EventHandlerCommandID   *int     `json:"event_handler_command_id"`
+	EventHandlerCommandArgs []string `json:"event_handler_command_args,omitzero"`
+
+	NoteURL         string `json:"note_url,omitzero"`
+	Note            string `json:"note,omitzero"`
+	ActionURL       string `json:"action_url,omitzero"`
+	IconID          *int   `json:"icon_id"`
+	IconAlternative string `json:"icon_alternative,omitzero"`
+	Comment         string `json:"comment,omitzero"`
+	IsActivated     bool   `json:"is_activated"`
+
+	Categories []NamedRef  `json:"categories,omitzero"`
+	Groups     []NamedRef  `json:"groups,omitzero"`
+	Templates  []NamedRef  `json:"templates,omitzero"`
+	Macros     []HostMacro `json:"macros,omitzero"`
 }
 
 // CreateHostRequest is the request body for creating a host.
@@ -176,6 +255,21 @@ func (s *HostService) All(ctx context.Context, opts ...ListOption) iter.Seq2[*Ho
 // Returns *NotFoundError if not found.
 func (s *HostService) GetByID(ctx context.Context, id int) (*Host, error) {
 	return getByID(ctx, s.List, "host", id)
+}
+
+// Get returns the full configuration of the host with the given ID via a
+// direct GET request, including custom macros defined directly on the host
+// (template- and command-inherited macros are not included).
+//
+// This requires Centreon 25.10 or later; earlier versions return an *APIError
+// with HTTP status 404. For a version-independent lookup of the list
+// representation (without macros), use GetByID.
+func (s *HostService) Get(ctx context.Context, id int) (*HostDetail, error) {
+	var h HostDetail
+	if err := s.client.get(ctx, fmt.Sprintf("/configuration/hosts/%d", id), &h); err != nil {
+		return nil, err
+	}
+	return &h, nil
 }
 
 // Create creates a new host and returns its ID.

--- a/hosts_test.go
+++ b/hosts_test.go
@@ -416,3 +416,150 @@ func TestHostService_Update_WithRelationshipFields(t *testing.T) {
 		t.Fatalf("Update: %v", err)
 	}
 }
+
+// realisticHostDetailJSON returns a full GET /configuration/hosts/{id} detail
+// payload (Centreon 25.10+) for host 42, exercising nullable fields and both a
+// plain and a password (null-value) macro.
+func realisticHostDetailJSON() map[string]any {
+	return map[string]any{
+		"id":                          42,
+		"monitoring_server_id":        4,
+		"name":                        "host-42",
+		"address":                     "10.0.0.42",
+		"alias":                       "Host 42",
+		"snmp_version":                "2c",
+		"snmp_community":              "public",
+		"geo_coords":                  "48.10,12.5",
+		"timezone_id":                 nil,
+		"severity_id":                 1,
+		"check_command_id":            1,
+		"check_command_args":          []string{"0", "OK"},
+		"check_timeperiod_id":         nil,
+		"max_check_attempts":          3,
+		"normal_check_interval":       5,
+		"retry_check_interval":        1,
+		"active_check_enabled":        2,
+		"passive_check_enabled":       2,
+		"notification_enabled":        2,
+		"notification_options":        nil,
+		"notification_interval":       nil,
+		"notification_timeperiod_id":  1,
+		"add_inherited_contact_group": false,
+		"add_inherited_contact":       false,
+		"first_notification_delay":    nil,
+		"recovery_notification_delay": nil,
+		"acknowledgement_timeout":     nil,
+		"freshness_checked":           0,
+		"freshness_threshold":         nil,
+		"flap_detection_enabled":      0,
+		"low_flap_threshold":          nil,
+		"high_flap_threshold":         nil,
+		"event_handler_enabled":       0,
+		"event_handler_command_id":    nil,
+		"event_handler_command_args":  []string{},
+		"note_url":                    "",
+		"note":                        "",
+		"action_url":                  "",
+		"icon_id":                     nil,
+		"icon_alternative":            "",
+		"comment":                     "",
+		"is_activated":                true,
+		"categories":                  []map[string]any{{"id": 29, "name": "Managed_VPN"}},
+		"groups":                      []map[string]any{{"id": 1310, "name": "test-group"}},
+		"templates":                   []map[string]any{{"id": 684, "name": "Ping_only"}},
+		"macros": []map[string]any{
+			{"id": 101, "name": "WARNINGTHRESHOLD", "value": "80", "is_password": false, "description": "warn level"},
+			{"id": 102, "name": "SNMPPASSWORD", "value": nil, "is_password": true, "description": nil},
+		},
+	}
+}
+
+func TestHostService_Get(t *testing.T) {
+	mux, c := newTestMux(t)
+
+	mux.HandleFunc("GET /centreon/api/latest/configuration/hosts/42", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, realisticHostDetailJSON())
+	})
+
+	h, err := c.Hosts.Get(t.Context(), 42)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if h.ID != 42 {
+		t.Errorf("ID = %d, want 42", h.ID)
+	}
+	if h.MonitoringServerID != 4 {
+		t.Errorf("MonitoringServerID = %d, want 4", h.MonitoringServerID)
+	}
+	if h.CheckTimeperiodID != nil {
+		t.Errorf("CheckTimeperiodID = %v, want nil", h.CheckTimeperiodID)
+	}
+	if h.MaxCheckAttempts == nil || *h.MaxCheckAttempts != 3 {
+		t.Errorf("MaxCheckAttempts = %v, want 3", h.MaxCheckAttempts)
+	}
+	if len(h.Templates) != 1 || h.Templates[0].ID != 684 {
+		t.Errorf("Templates = %+v, want [{ID:684 ...}]", h.Templates)
+	}
+
+	checkHostDetailMacros(t, h.Macros)
+}
+
+// checkHostDetailMacros verifies the plain and password macros decoded from a
+// host detail response, including the nil Value on a masked password macro.
+func checkHostDetailMacros(t *testing.T, macros []HostMacro) {
+	t.Helper()
+
+	t.Run("macros", func(t *testing.T) {
+		if len(macros) != 2 {
+			t.Fatalf("len(Macros) = %d, want 2", len(macros))
+		}
+		if macros[0].ID != 101 {
+			t.Errorf("Macros[0].ID = %d, want 101", macros[0].ID)
+		}
+		if macros[0].Value == nil || *macros[0].Value != "80" {
+			t.Errorf("Macros[0].Value = %v, want \"80\"", macros[0].Value)
+		}
+		if macros[0].Description != "warn level" {
+			t.Errorf("Macros[0].Description = %q, want %q", macros[0].Description, "warn level")
+		}
+	})
+
+	t.Run("password_macro_null_value", func(t *testing.T) {
+		if len(macros) != 2 {
+			t.Fatalf("len(Macros) = %d, want 2", len(macros))
+		}
+		pw := macros[1]
+		if !pw.IsPassword {
+			t.Errorf("Macros[1].IsPassword = false, want true")
+		}
+		if pw.Value != nil {
+			t.Errorf("Macros[1].Value = %q, want nil (password masked)", *pw.Value)
+		}
+		if pw.Description != "" {
+			t.Errorf("Macros[1].Description = %q, want empty", pw.Description)
+		}
+	})
+}
+
+func TestHostService_Get_NotFound(t *testing.T) {
+	mux, c := newTestMux(t)
+
+	mux.HandleFunc("GET /centreon/api/latest/configuration/hosts/999", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusNotFound, map[string]any{"code": 404, "message": "Host not found"})
+	})
+
+	h, err := c.Hosts.Get(t.Context(), 999)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if h != nil {
+		t.Errorf("expected nil host, got %+v", h)
+	}
+	apiErr, ok := errors.AsType[*APIError](err)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.HTTPStatus != 404 {
+		t.Errorf("APIError.HTTPStatus = %d, want 404", apiErr.HTTPStatus)
+	}
+}

--- a/services.go
+++ b/services.go
@@ -22,6 +22,81 @@ type Service struct {
 	IsActivated         bool       `json:"is_activated"`
 }
 
+// ServiceMacro is a custom macro as returned by ServiceService.Get
+// (GET /configuration/services/{id}) on Centreon 25.10+. Unlike HostMacro it
+// carries no ID. Value is nil when IsPassword is true because the API masks
+// password values on read.
+type ServiceMacro struct {
+	Name        string  `json:"name"`
+	Value       *string `json:"value"`
+	IsPassword  bool    `json:"is_password"`
+	Description string  `json:"description,omitzero"`
+}
+
+// ServiceDetail is the full service configuration returned by
+// ServiceService.Get (GET /configuration/services/{id}), including custom
+// macros.
+//
+// This endpoint requires Centreon 25.10 or later; earlier versions have no
+// GET route for a single service and return an *APIError with HTTP status
+// 404. Unlike Service (the list shape), references other than categories and
+// groups are raw IDs. Per the Centreon 25.10 API, Macros includes macros
+// inherited from service templates and commands in addition to those defined
+// on the service itself.
+type ServiceDetail struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	HostID    int    `json:"host_id"`
+	GeoCoords string `json:"geo_coords,omitzero"`
+	Comment   string `json:"comment,omitzero"`
+
+	ServiceTemplateID *int `json:"service_template_id"`
+
+	CheckCommandID      *int     `json:"check_command_id"`
+	CheckCommandArgs    []string `json:"check_command_args,omitzero"`
+	CheckTimeperiodID   *int     `json:"check_timeperiod_id"`
+	MaxCheckAttempts    *int     `json:"max_check_attempts"`
+	NormalCheckInterval *int     `json:"normal_check_interval"`
+	RetryCheckInterval  *int     `json:"retry_check_interval"`
+	ActiveCheckEnabled  int      `json:"active_check_enabled"`
+	PassiveCheckEnabled int      `json:"passive_check_enabled"`
+	VolatilityEnabled   int      `json:"volatility_enabled"`
+
+	NotificationEnabled               int  `json:"notification_enabled"`
+	IsContactAdditiveInheritance      bool `json:"is_contact_additive_inheritance"`
+	IsContactGroupAdditiveInheritance bool `json:"is_contact_group_additive_inheritance"`
+	NotificationInterval              *int `json:"notification_interval"`
+	NotificationTimeperiodID          *int `json:"notification_timeperiod_id"`
+	NotificationType                  *int `json:"notification_type"`
+	FirstNotificationDelay            *int `json:"first_notification_delay"`
+	RecoveryNotificationDelay         *int `json:"recovery_notification_delay"`
+	AcknowledgementTimeout            *int `json:"acknowledgement_timeout"`
+
+	FreshnessChecked   int  `json:"freshness_checked"`
+	FreshnessThreshold *int `json:"freshness_threshold"`
+
+	FlapDetectionEnabled int  `json:"flap_detection_enabled"`
+	LowFlapThreshold     *int `json:"low_flap_threshold"`
+	HighFlapThreshold    *int `json:"high_flap_threshold"`
+
+	EventHandlerEnabled     int      `json:"event_handler_enabled"`
+	EventHandlerCommandID   *int     `json:"event_handler_command_id"`
+	EventHandlerCommandArgs []string `json:"event_handler_command_args,omitzero"`
+
+	GraphTemplateID *int   `json:"graph_template_id"`
+	Note            string `json:"note,omitzero"`
+	NoteURL         string `json:"note_url,omitzero"`
+	ActionURL       string `json:"action_url,omitzero"`
+	IconID          *int   `json:"icon_id"`
+	IconAlternative string `json:"icon_alternative,omitzero"`
+	SeverityID      *int   `json:"severity_id"`
+	IsActivated     bool   `json:"is_activated"`
+
+	Categories []NamedRef     `json:"categories,omitzero"`
+	Groups     []NamedRef     `json:"groups,omitzero"`
+	Macros     []ServiceMacro `json:"macros,omitzero"`
+}
+
 // CreateServiceRequest is the request body for creating a service.
 type CreateServiceRequest struct {
 	// Required
@@ -150,6 +225,21 @@ func (s *ServiceService) All(ctx context.Context, opts ...ListOption) iter.Seq2[
 func (s *ServiceService) ListByHost(ctx context.Context, hostID int, opts ...ListOption) (*ListResponse[Service], error) {
 	opts = append(opts, WithSearch(Eq("host.id", hostID)))
 	return s.List(ctx, opts...)
+}
+
+// Get returns the full configuration of the service with the given ID via a
+// direct GET request, including custom macros. Per the Centreon 25.10 API,
+// the returned macros also include those inherited from service templates and
+// commands.
+//
+// This requires Centreon 25.10 or later; earlier versions return an *APIError
+// with HTTP status 404.
+func (s *ServiceService) Get(ctx context.Context, id int) (*ServiceDetail, error) {
+	var svc ServiceDetail
+	if err := s.client.get(ctx, fmt.Sprintf("/configuration/services/%d", id), &svc); err != nil {
+		return nil, err
+	}
+	return &svc, nil
 }
 
 // Create creates a new service and returns its ID.

--- a/services_test.go
+++ b/services_test.go
@@ -2,6 +2,7 @@ package centreon
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 )
@@ -272,5 +273,133 @@ func TestServiceService_Update_WithRelationshipFields(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Update: %v", err)
+	}
+}
+
+// realisticServiceDetailJSON returns a full GET /configuration/services/{id}
+// detail payload (Centreon 25.10+) for service 7 on host 42, exercising
+// nullable fields and both a plain and a password (null-value) macro. Note the
+// service macro shape has no "id" key, unlike the host macro shape.
+func realisticServiceDetailJSON() map[string]any {
+	return map[string]any{
+		"id":                                    7,
+		"name":                                  "service-07",
+		"host_id":                               42,
+		"geo_coords":                            "",
+		"comment":                               "",
+		"service_template_id":                   12,
+		"check_command_id":                      nil,
+		"check_command_args":                    []string{"80", "90"},
+		"check_timeperiod_id":                   nil,
+		"max_check_attempts":                    3,
+		"normal_check_interval":                 nil,
+		"retry_check_interval":                  nil,
+		"active_check_enabled":                  2,
+		"passive_check_enabled":                 2,
+		"volatility_enabled":                    2,
+		"notification_enabled":                  2,
+		"is_contact_additive_inheritance":       false,
+		"is_contact_group_additive_inheritance": false,
+		"notification_interval":                 nil,
+		"notification_timeperiod_id":            1,
+		"notification_type":                     nil,
+		"first_notification_delay":              nil,
+		"recovery_notification_delay":           nil,
+		"acknowledgement_timeout":               nil,
+		"freshness_checked":                     2,
+		"freshness_threshold":                   nil,
+		"flap_detection_enabled":                2,
+		"low_flap_threshold":                    nil,
+		"high_flap_threshold":                   nil,
+		"event_handler_enabled":                 2,
+		"event_handler_command_id":              nil,
+		"event_handler_command_args":            []string{},
+		"graph_template_id":                     nil,
+		"note":                                  "",
+		"note_url":                              "",
+		"action_url":                            "",
+		"icon_id":                               nil,
+		"icon_alternative":                      "",
+		"severity_id":                           nil,
+		"is_activated":                          true,
+		"categories":                            []map[string]any{{"id": 1, "name": "svc-cat"}},
+		"groups":                                []map[string]any{{"id": 2, "name": "svc-grp"}},
+		"macros": []map[string]any{
+			{"name": "USER1", "value": "/usr/lib/nagios/plugins", "is_password": false, "description": "plugin path"},
+			{"name": "SERVICEPASSWORD", "value": nil, "is_password": true, "description": nil},
+		},
+	}
+}
+
+func TestServiceService_Get(t *testing.T) {
+	mux, c := newTestMux(t)
+
+	mux.HandleFunc("GET /centreon/api/latest/configuration/services/7", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, realisticServiceDetailJSON())
+	})
+
+	svc, err := c.Services.Get(t.Context(), 7)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if svc.ID != 7 {
+		t.Errorf("ID = %d, want 7", svc.ID)
+	}
+	if svc.HostID != 42 {
+		t.Errorf("HostID = %d, want 42", svc.HostID)
+	}
+	if svc.ServiceTemplateID == nil || *svc.ServiceTemplateID != 12 {
+		t.Errorf("ServiceTemplateID = %v, want 12", svc.ServiceTemplateID)
+	}
+	if svc.CheckCommandID != nil {
+		t.Errorf("CheckCommandID = %v, want nil", svc.CheckCommandID)
+	}
+
+	t.Run("macros", func(t *testing.T) {
+		if len(svc.Macros) != 2 {
+			t.Fatalf("len(Macros) = %d, want 2", len(svc.Macros))
+		}
+		if svc.Macros[0].Name != "USER1" {
+			t.Errorf("Macros[0].Name = %q, want USER1", svc.Macros[0].Name)
+		}
+		if svc.Macros[0].Value == nil || *svc.Macros[0].Value != "/usr/lib/nagios/plugins" {
+			t.Errorf("Macros[0].Value = %v, want plugin path", svc.Macros[0].Value)
+		}
+	})
+
+	t.Run("password_macro_null_value", func(t *testing.T) {
+		if len(svc.Macros) != 2 {
+			t.Fatalf("len(Macros) = %d, want 2", len(svc.Macros))
+		}
+		pw := svc.Macros[1]
+		if !pw.IsPassword {
+			t.Errorf("Macros[1].IsPassword = false, want true")
+		}
+		if pw.Value != nil {
+			t.Errorf("Macros[1].Value = %q, want nil (password masked)", *pw.Value)
+		}
+	})
+}
+
+func TestServiceService_Get_NotFound(t *testing.T) {
+	mux, c := newTestMux(t)
+
+	mux.HandleFunc("GET /centreon/api/latest/configuration/services/999", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusNotFound, map[string]any{"code": 404, "message": "Service not found"})
+	})
+
+	svc, err := c.Services.Get(t.Context(), 999)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if svc != nil {
+		t.Errorf("expected nil service, got %+v", svc)
+	}
+	apiErr, ok := errors.AsType[*APIError](err)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.HTTPStatus != 404 {
+		t.Errorf("APIError.HTTPStatus = %d, want 404", apiErr.HTTPStatus)
 	}
 }


### PR DESCRIPTION
## What

Adds `HostService.Get(ctx, id)` and `ServiceService.Get(ctx, id)`, which call the per-id configuration detail endpoints `GET /configuration/hosts/{id}` and `GET /configuration/services/{id}` and decode the full configuration including a `macros` array. This is the client side of #36 (reading custom macros).

## Why this shape (the issue's premise changed after investigation)

The original #36 assumed that adding a `Macros` field to the read struct would work, maybe plus a detail GET. Investigation against a live Centreon 24.10.26 instance and the `centreon/centreon` source showed otherwise:

- On 24.10 there is no v2 REST way to read macros at all. The list endpoints never return macros, and the per-id config route only allows DELETE and PATCH. That is a Centreon API limitation, not a client bug, so adding a field alone does nothing.
- The per-id GET detail endpoints are new in Centreon 25.10, backend-gated with `condition: request.attributes.get('version') >= 25.10`, and are the only way to read custom macros over the v2 API.

Full evidence, including Centreon staff confirmation on the community forum, is captured in #36.

## What changed

- New read types modeling the 25.10 detail responses. `HostDetail` and `ServiceDetail` carry the full configuration plus a macros slice. Read macros use `HostMacro` (with an `id`) and `ServiceMacro` (no `id`); `Value` is `*string` and is nil for password macros, which the API masks on read. The existing write-side `Macro` type is unchanged.
- The existing list-based `GetByID` is unchanged and remains the version-independent (macro-free) lookup for hosts.
- README CRUD table corrected: `Services` never had a by-id lookup (`ServiceService` has no `GetByID`, and the services endpoint has no search-by-service-id), and `Hosts` now offers both `Get` (25.10+) and `GetByID`.
- Fixture tests round-trip a macros array including a password macro with a null value, for both hosts and services, plus 404 not-found coverage on both.

## Verification

- `go build`, `go vet`, `go test -race`, and `golangci-lint` pass locally. (One `goconst` in `client.go` is pre-existing, untouched here, and not flagged by the CI-pinned linter version.)
- Read-side field names and the macro schema are verified against `centreon/centreon` `dev-25.10.x` source (`GetHostResponse.yaml`, `GetServiceResponse.yaml`, `macro.yaml`).
- Reviewed by a multi-agent pre-push gate (reuse, correctness, quality, integration, regression, test quality) plus a Gemini pass. All converged to GO; the only findings were doc and test-parity, which are included in this PR.

## Not yet done: live verification

The only live instance available is 24.10, where these endpoints do not exist, so the end-to-end macro round-trip cannot be exercised yet. This ships schema-accurate and fixture-tested; the live round-trip is owed after a 25.10 upgrade. I would keep #36 open to track that final step, or it can be closed on merge if you prefer to track the live check separately.

Refs #36
