### PR TITLE
feat: add service timeline and metrics monitoring methods (#38, #39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ func main() {
 |----------|---------|
 | Unified Resources | List, GetHost, GetService |
 | Monitoring Hosts | List, Get, StatusCounts, Services, Timeline |
-| Monitoring Services | List, StatusCounts |
+| Monitoring Services | List, StatusCounts, Timeline, Metrics |
 | Downtimes | List, Get, Cancel, ListForHost, ListForService, CreateForHost, CreateForService, CancelForHost, CancelForService |
 | Acknowledgements | List, Get, ListForHost, ListForService, CreateForHost, CreateForService, CancelForHost, CancelForService |
 | Notification Policies | GetForHost, GetForService |
@@ -221,13 +221,13 @@ resp, err := client.Hosts.List(ctx, centreon.WithSearch(filter))
 The API uses two update methods depending on the resource:
 
 ```go
-// PATCH (partial update) — hosts, services, templates
+// PATCH (partial update): hosts, services, templates
 // Only specified fields are changed. Use pointer fields.
 err := client.Hosts.Update(ctx, hostID, centreon.UpdateHostRequest{
     Alias: new("updated alias"),  // Go 1.26 new(expr)
 })
 
-// PUT (full replacement) — groups, categories, severities, time periods
+// PUT (full replacement): groups, categories, severities, time periods
 // All fields are sent. Omitted fields reset to defaults.
 err := client.HostGroups.Update(ctx, groupID, centreon.UpdateHostGroupRequest{
     Name:  "linux-servers",
@@ -299,4 +299,4 @@ client, _ := centreon.NewClient(url, centreon.WithVersion("v24.04"))
 
 ## License
 
-Apache License 2.0 — see [LICENSE](LICENSE) for details.
+Apache License 2.0. See [LICENSE](LICENSE) for details.

--- a/monitoring_services.go
+++ b/monitoring_services.go
@@ -2,6 +2,7 @@ package centreon
 
 import (
 	"context"
+	"fmt"
 	"iter"
 )
 
@@ -40,6 +41,21 @@ type ServiceStatusCount struct {
 	Total    int         `json:"total"`
 }
 
+// Metric is a performance metric of a service, as returned by
+// GET /monitoring/hosts/{host_id}/services/{service_id}/metrics.
+// Pointer fields are nil when the API returns JSON null, which is
+// common for thresholds that are not configured on the metric.
+type Metric struct {
+	ID                    int      `json:"id"`
+	Name                  string   `json:"name"`
+	Unit                  string   `json:"unit"`
+	CurrentValue          *float64 `json:"current_value"`
+	WarningHighThreshold  *float64 `json:"warning_high_threshold"`
+	WarningLowThreshold   *float64 `json:"warning_low_threshold"`
+	CriticalHighThreshold *float64 `json:"critical_high_threshold"`
+	CriticalLowThreshold  *float64 `json:"critical_low_threshold"`
+}
+
 // MonitoringServiceService provides access to the monitoring services endpoints.
 type MonitoringServiceService struct {
 	client *Client
@@ -64,4 +80,22 @@ func (s *MonitoringServiceService) StatusCounts(ctx context.Context) (*ServiceSt
 		return nil, err
 	}
 	return &result, nil
+}
+
+// Timeline returns a paginated list of timeline events for a given service on a host.
+func (s *MonitoringServiceService) Timeline(ctx context.Context, hostID, serviceID int, opts ...ListOption) (*ListResponse[TimelineEvent], error) {
+	var resp ListResponse[TimelineEvent]
+	err := s.client.list(ctx, fmt.Sprintf("/monitoring/hosts/%d/services/%d/timeline", hostID, serviceID), opts, &resp)
+	return &resp, err
+}
+
+// Metrics returns the performance metrics for a given service on a host.
+// The endpoint returns a plain JSON array, so there is no pagination and
+// no ListOption support.
+func (s *MonitoringServiceService) Metrics(ctx context.Context, hostID, serviceID int) ([]Metric, error) {
+	var result []Metric
+	if err := s.client.get(ctx, fmt.Sprintf("/monitoring/hosts/%d/services/%d/metrics", hostID, serviceID), &result); err != nil {
+		return nil, err
+	}
+	return result, nil
 }

--- a/monitoring_services_test.go
+++ b/monitoring_services_test.go
@@ -3,7 +3,9 @@ package centreon
 import (
 	"encoding/json"
 	"net/http"
+	"reflect"
 	"testing"
+	"time"
 )
 
 func TestMonitoringServiceService_List(t *testing.T) {
@@ -180,5 +182,199 @@ func TestMonitoringServiceService_StatusCounts(t *testing.T) {
 	}
 	if counts.Total != 61 {
 		t.Errorf("Total = %d, want 61", counts.Total)
+	}
+}
+
+func TestMonitoringServiceService_Timeline(t *testing.T) {
+	mux, c := newTestMux(t)
+
+	eventTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	var gotLimit string
+
+	mux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/10/services/20/timeline", func(w http.ResponseWriter, r *http.Request) {
+		gotLimit = r.URL.Query().Get("limit")
+		// Map-based body pins the JSON tags independently of TimelineEvent, so a
+		// tag typo cannot round-trip invisibly. The first event carries the extra
+		// fields the live API sends (status, tries, start_date, end_date, contact)
+		// to confirm the struct correctly ignores them.
+		writeJSON(w, http.StatusOK, map[string]any{
+			"result": []map[string]any{
+				{
+					"id":         1,
+					"type":       "event",
+					"date":       "2024-01-15T10:00:00Z",
+					"content":    "OK - 10.0.0.1: rta 0.207ms lost 0%",
+					"start_date": nil,
+					"end_date":   nil,
+					"contact":    nil,
+					"status":     map[string]any{"code": 0, "name": "OK", "severity_code": 5},
+					"tries":      1,
+				},
+				{
+					"id":      2,
+					"type":    "notification",
+					"date":    "2024-01-15T10:00:00Z",
+					"content": "Notification sent",
+				},
+			},
+			"meta": map[string]any{"page": 1, "limit": 10, "total": 2},
+		})
+	})
+
+	resp, err := c.MonitoringServices.Timeline(t.Context(), 10, 20, WithLimit(5))
+	if err != nil {
+		t.Fatalf("Timeline: %v", err)
+	}
+	// Confirms the ListOption variadic is forwarded to the query string.
+	if gotLimit != "5" {
+		t.Errorf("forwarded limit = %q, want %q", gotLimit, "5")
+	}
+	if len(resp.Result) != 2 {
+		t.Fatalf("len(Result) = %d, want 2", len(resp.Result))
+	}
+	if resp.Result[0].Type != "event" {
+		t.Errorf("Result[0].Type = %q, want %q", resp.Result[0].Type, "event")
+	}
+	if !resp.Result[0].Date.Equal(eventTime) {
+		t.Errorf("Result[0].Date = %v, want %v", resp.Result[0].Date, eventTime)
+	}
+	if resp.Result[1].Content != "Notification sent" {
+		t.Errorf("Result[1].Content = %q, want %q", resp.Result[1].Content, "Notification sent")
+	}
+}
+
+func TestMonitoringServiceService_Metrics(t *testing.T) {
+	mux, c := newTestMux(t)
+
+	// The payload is []map[string]any on purpose: it pins the JSON tags
+	// independently of the Metric struct, so a tag typo cannot cancel out.
+	// nil map values marshal to JSON null, exercising the pointer fields.
+	mux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/10/services/20/metrics", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, []map[string]any{
+			{
+				"id":                      5053,
+				"name":                    "pl",
+				"unit":                    "%",
+				"current_value":           0,
+				"warning_high_threshold":  75,
+				"warning_low_threshold":   0,
+				"critical_high_threshold": 100,
+				"critical_low_threshold":  0,
+			},
+			{
+				"id":                      5054,
+				"name":                    "rtmax",
+				"unit":                    "ms",
+				"current_value":           0.474,
+				"warning_high_threshold":  nil,
+				"warning_low_threshold":   nil,
+				"critical_high_threshold": nil,
+				"critical_low_threshold":  nil,
+			},
+		})
+	})
+
+	metrics, err := c.MonitoringServices.Metrics(t.Context(), 10, 20)
+	if err != nil {
+		t.Fatalf("Metrics: %v", err)
+	}
+	if len(metrics) != 2 {
+		t.Fatalf("len(metrics) = %d, want 2", len(metrics))
+	}
+
+	pl := metrics[0]
+	if pl.ID != 5053 {
+		t.Errorf("metrics[0].ID = %d, want 5053", pl.ID)
+	}
+	if pl.Name != "pl" {
+		t.Errorf("metrics[0].Name = %q, want %q", pl.Name, "pl")
+	}
+	if pl.Unit != "%" {
+		t.Errorf("metrics[0].Unit = %q, want %q", pl.Unit, "%")
+	}
+	if pl.CurrentValue == nil {
+		t.Fatal("metrics[0].CurrentValue = nil, want 0")
+	}
+	if *pl.CurrentValue != 0 {
+		t.Errorf("*metrics[0].CurrentValue = %v, want 0", *pl.CurrentValue)
+	}
+	if pl.WarningHighThreshold == nil {
+		t.Fatal("metrics[0].WarningHighThreshold = nil, want 75")
+	}
+	if *pl.WarningHighThreshold != 75 {
+		t.Errorf("*metrics[0].WarningHighThreshold = %v, want 75", *pl.WarningHighThreshold)
+	}
+
+	rtmax := metrics[1]
+	if rtmax.Unit != "ms" {
+		t.Errorf("metrics[1].Unit = %q, want %q", rtmax.Unit, "ms")
+	}
+	if rtmax.CurrentValue == nil {
+		t.Fatal("metrics[1].CurrentValue = nil, want 0.474")
+	}
+	if *rtmax.CurrentValue != 0.474 {
+		t.Errorf("*metrics[1].CurrentValue = %v, want 0.474", *rtmax.CurrentValue)
+	}
+	if rtmax.WarningHighThreshold != nil {
+		t.Errorf("metrics[1].WarningHighThreshold = %v, want nil", *rtmax.WarningHighThreshold)
+	}
+	if rtmax.CriticalHighThreshold != nil {
+		t.Errorf("metrics[1].CriticalHighThreshold = %v, want nil", *rtmax.CriticalHighThreshold)
+	}
+}
+
+// TestMonitoringServiceService_Metrics_RoundTrip verifies that Metric
+// deserializes correctly from the exact JSON the live Centreon API returns.
+func TestMonitoringServiceService_Metrics_RoundTrip(t *testing.T) {
+	apiJSON := `[
+		{"id":5053,"name":"pl","unit":"%","current_value":0,"warning_high_threshold":75,"warning_low_threshold":0,"critical_high_threshold":100,"critical_low_threshold":0},
+		{"id":5054,"name":"rtmax","unit":"ms","current_value":0.474,"warning_high_threshold":null,"warning_low_threshold":null,"critical_high_threshold":null,"critical_low_threshold":null}
+	]`
+
+	var metrics []Metric
+	if err := json.Unmarshal([]byte(apiJSON), &metrics); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	// reflect.DeepEqual dereferences the *float64 fields, so it distinguishes
+	// a set threshold from a null one (nil pointer) across the whole slice.
+	f := func(v float64) *float64 { return &v }
+	want := []Metric{
+		{
+			ID: 5053, Name: "pl", Unit: "%",
+			CurrentValue:          f(0),
+			WarningHighThreshold:  f(75),
+			WarningLowThreshold:   f(0),
+			CriticalHighThreshold: f(100),
+			CriticalLowThreshold:  f(0),
+		},
+		{
+			ID: 5054, Name: "rtmax", Unit: "ms",
+			CurrentValue: f(0.474),
+			// warning/critical thresholds stay nil: the live payload sends null.
+		},
+	}
+	if !reflect.DeepEqual(metrics, want) {
+		// Marshal back to JSON for a readable diff: pointer fields render as
+		// their numeric value, and a nil threshold renders as null.
+		gotJSON, _ := json.Marshal(metrics) //nolint:errchkjson // Metric marshals without error
+		wantJSON, _ := json.Marshal(want)   //nolint:errchkjson // Metric marshals without error
+		t.Errorf("round-trip mismatch:\n got  %s\n want %s", gotJSON, wantJSON)
+	}
+}
+
+func TestMonitoringServiceService_Metrics_Error(t *testing.T) {
+	mux, c := newTestMux(t)
+
+	mux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/10/services/20/metrics", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"code": 500, "message": "boom"})
+	})
+
+	metrics, err := c.MonitoringServices.Metrics(t.Context(), 10, 20)
+	if err == nil {
+		t.Fatal("Metrics: want error on HTTP 500, got nil")
+	}
+	if metrics != nil {
+		t.Errorf("Metrics result = %v, want nil on error", metrics)
 	}
 }


### PR DESCRIPTION
## Summary

Adds two methods to `MonitoringServiceService`: `Timeline` (per-service event timeline) and `Metrics` (per-service performance metrics). Both are thin wrappers over the existing `client.list` / `client.get` helpers and mirror the existing host-side methods. The metrics endpoint returns a bare JSON array, so it decodes into `[]Metric` with no pagination envelope; the per-service timeline returns the standard `{result, meta}` envelope and reuses the existing `TimelineEvent` type. Both wire formats were verified against a live Centreon 24.10.26 instance before finalizing.

The new `Metric` type models `current_value` and the four warning/critical thresholds as `*float64`, so a configured zero stays distinct from an unset value (JSON `null`); `unit` is a plain string. Reusing `TimelineEvent` (rather than adding a richer type) keeps parity with the existing `MonitoringHostService.Timeline`, which is what the issue asked for.

## Related Issues

Closes #38
Closes #39

## Test Plan

- [x] Fixture tests for both methods, plus a round-trip over the exact live payload
- [x] Map-based mock bodies pin the JSON tags independently of the structs (a tag typo cannot round-trip invisibly)
- [x] Each new test sabotage-verified: it fails when the corresponding production line is broken
- [x] Live end-to-end smoke test through the client against a 24.10 instance (metrics values and null thresholds decode correctly; timeline events parse)
- [x] gofmt, go vet, go test, golangci-lint clean (the only lint hit is a pre-existing unrelated goconst in client.go that CI's pinned linter version does not flag)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added monitoring service timeline retrieval with pagination and filtering options.
  - Added metrics retrieval, including metric values, units, and optional thresholds.
  - Expanded monitoring documentation to describe timeline and metrics support.

- **Bug Fixes**
  - Improved handling of nullable metric thresholds and server-side errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->